### PR TITLE
Allow viewing two stocks

### DIFF
--- a/client/src/components/data-table.tsx
+++ b/client/src/components/data-table.tsx
@@ -120,7 +120,9 @@ export default function DataTable({ symbol }: DataTableProps) {
     <Card className="bg-dark-secondary border-dark-surface shadow-xl overflow-hidden">
       <CardContent className="p-6 border-b border-dark-surface">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
-          <h2 className="text-lg font-semibold text-text-primary mb-4 sm:mb-0">Historical Data</h2>
+          <h2 className="text-lg font-semibold text-text-primary mb-4 sm:mb-0">
+            Historical Data - {symbol}
+          </h2>
           <Button
             onClick={handleExportCSV}
             className="bg-accent-green hover:bg-green-600 text-white flex items-center space-x-2"

--- a/client/src/components/stock-overview.tsx
+++ b/client/src/components/stock-overview.tsx
@@ -71,7 +71,11 @@ export default function StockOverview({ symbol }: StockOverviewProps) {
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold text-text-primary mb-4">
+        Overview - {stockData.companyName || symbol}
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {metrics.map((metric, index) => (
         <Card key={index} className="bg-dark-secondary border-dark-surface hover:shadow-2xl transition-shadow duration-200">
           <CardContent className="p-6">
@@ -106,6 +110,7 @@ export default function StockOverview({ symbol }: StockOverviewProps) {
           </CardContent>
         </Card>
       ))}
+      </div>
     </div>
   );
 }

--- a/client/src/components/stock-search.tsx
+++ b/client/src/components/stock-search.tsx
@@ -69,7 +69,7 @@ export default function StockSearch({ onSymbolSelected }: StockSearchProps) {
             <Input
               id="stock-symbol"
               type="text"
-              placeholder="Enter symbol (e.g., AAPL, GOOGL, TSLA)"
+              placeholder="Enter symbol (add up to 2, e.g., AAPL)"
               value={symbol}
               onChange={(e) => setSymbol(e.target.value.toUpperCase())}
               onKeyPress={handleKeyPress}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -6,7 +6,7 @@ import InteractiveChart from "@/components/interactive-chart";
 import DataTable from "@/components/data-table";
 
 export default function Dashboard() {
-  const [selectedSymbol, setSelectedSymbol] = useState<string>("");
+  const [selectedSymbols, setSelectedSymbols] = useState<string[]>([]);
 
   return (
     <div className="min-h-screen bg-dark-primary">
@@ -29,20 +29,29 @@ export default function Dashboard() {
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Stock Search Section */}
-        <StockSearch onSymbolSelected={setSelectedSymbol} />
-        
-        {selectedSymbol && (
-          <>
+        <StockSearch
+          onSymbolSelected={(symbol) =>
+            setSelectedSymbols((prev) => {
+              const sym = symbol.toUpperCase();
+              if (prev.includes(sym)) return prev;
+              if (prev.length < 2) return [...prev, sym];
+              return [prev[1], sym];
+            })
+          }
+        />
+
+        {selectedSymbols.map((sym) => (
+          <div key={sym}>
             {/* Stock Overview Cards */}
-            <StockOverview symbol={selectedSymbol} />
-            
+            <StockOverview symbol={sym} />
+
             {/* Chart Section */}
-            <InteractiveChart symbol={selectedSymbol} />
-            
+            <InteractiveChart symbol={sym} />
+
             {/* Data Table Section */}
-            <DataTable symbol={selectedSymbol} />
-          </>
-        )}
+            <DataTable symbol={sym} />
+          </div>
+        ))}
       </main>
 
       {/* Footer */}


### PR DESCRIPTION
## Summary
- support showing two tickers by storing an array of selected symbols
- show symbol-specific headings in overview and historical table
- hint in search input about multiple symbols

## Testing
- `npm install` *(fails: ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_687efa5c0ca48332b64e24c8790a4be5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing data for up to two stock symbols simultaneously on the dashboard.

* **Enhancements**
  * Section headings in the data table and stock overview now display the selected symbol or company name for improved clarity.
  * Updated stock search input placeholder to better guide users on adding up to two symbols.

* **Style**
  * Improved layout and spacing in the stock overview section for a clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->